### PR TITLE
Graph css fix

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -116,5 +116,5 @@ textarea {
 }
 
 .dim {
-  opacity: 60%;
+  opacity: 0.6;
 }


### PR DESCRIPTION
In the dev server, css must be compiled differently that this was behaving as intended.  When deployed, it misbehaves, completely hiding the element intended rather than just dimming them.