### PR TITLE
add graph feature - show not finished exercises differently

### DIFF
--- a/src/components/graph/ExerciseTreeGraph.tsx
+++ b/src/components/graph/ExerciseTreeGraph.tsx
@@ -450,7 +450,7 @@ function drawLegend(
     .attr('x', x)
     .attr('y', y)
     .attr('height', 100)
-    .attr('width', 245)
+    .attr('width', 225)
     .style('fill', 'white')
     .style('stroke', 'black')
     .style('stroke-width', 1)
@@ -500,7 +500,7 @@ function drawLegend(
     .append('text')
     .style('font-size', '14px')
     .style('fill', '#000')
-    .text('concepts not fully implemented')
+    .text('exercise not complete')
     .attr('x', x + 35)
     .attr('y', y + 55)
 


### PR DESCRIPTION
Follow up to exercism/v3#2035, I looked at the source of what needed to be done, and for a minimal change the work required was small.  So here it is done to some extent.

When an exercise has a `null` UUID, the exercise will now display as a yellow square rather than a blue circle.

![Screenshot from 2020-07-20 00-03-36](https://user-images.githubusercontent.com/8953691/87904887-9c654900-ca1c-11ea-860e-ecd0bd92c387.png)

Legend has also been updated:

![Screenshot from 2020-07-20 00-03-24](https://user-images.githubusercontent.com/8953691/87904909-a8e9a180-ca1c-11ea-8e0b-b1543dcd81c9.png)

> Note, the legend in picture says "concepts not fully implemented", version in commit has that fixed to "exercise not complete"