### PR TITLE
Add unstyled UL to Header Navigation component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,9 +10,20 @@ export function Header(): JSX.Element {
         </HeaderLink>
 
         <nav>
-          <HeaderLink to="/">Tracks</HeaderLink>
-          <HeaderLink to="/exercises">Exercises</HeaderLink>
-          <HeaderLink to="/stories">Stories</HeaderLink>
+          <ul
+            className="list-unstyled"
+            style={{ display: 'flex', marginBottom: 0 }}
+          >
+            <li>
+              <HeaderLink to="/">Tracks</HeaderLink>
+            </li>
+            <li>
+              <HeaderLink to="/exercises">Exercises</HeaderLink>
+            </li>
+            <li>
+              <HeaderLink to="/stories">Stories</HeaderLink>
+            </li>
+          </ul>
         </nav>
       </div>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,10 +10,7 @@ export function Header(): JSX.Element {
         </HeaderLink>
 
         <nav>
-          <ul
-            className="list-unstyled"
-            style={{ display: 'flex', marginBottom: 0 }}
-          >
+          <ul className="list-unstyled d-flex mb-0">
             <li>
               <HeaderLink to="/">Tracks</HeaderLink>
             </li>


### PR DESCRIPTION
Fixes #93 and the orginal comment https://github.com/exercism/v3-dashboard/pull/91#discussion_r452257806

> For semantics, consider adding a list, as you're showing a list of links

- `display: 'flex'` to change the list direction to row
- `marginBottom: 0` to remove the `1em` margin bottom on the `ul` tag that would cause the header to increase in height.

